### PR TITLE
feat: add supabase auth multi-tenancy foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,106 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Plataforma B2B2C com Supabase e Next.js
 
-## Getting Started
+Este repositório contém a base de uma aplicação Next.js 14 (App Router) integrada ao Supabase com autenticação, multi-tenancy e controle de papéis (org, leader, rep) para um CRM de marketing multinível.
 
-First, run the development server:
+## Pré-requisitos
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- [Supabase CLI](https://supabase.com/docs/guides/cli) 1.158+.
+- Node.js 18+ com pnpm (ou npm/yarn/bun, adapte os comandos conforme necessário).
+- Variáveis de ambiente configuradas no arquivo `.env.local` do Next.js e em `.env` das Edge Functions (ver seção [Variáveis de ambiente](#variáveis-de-ambiente)).
+
+## Como rodar localmente
+
+1. Inicie os serviços do Supabase:
+   ```bash
+   supabase start
+   ```
+2. Aplique as migrações e seeds de desenvolvimento:
+   ```bash
+   supabase db reset --use-migra --seed supabase/seed.sql
+   ```
+   > O reset executa todas as migrações e popula dados demo (organização ACME, um líder e dois representantes).
+3. Opcional: sirva as Edge Functions localmente para testes integrados:
+   ```bash
+   supabase functions serve
+   ```
+4. Instale dependências do projeto e inicie o Next.js:
+   ```bash
+   pnpm install
+   pnpm dev
+   ```
+5. A aplicação ficará disponível em `http://localhost:3000`.
+
+## Configuração de autenticação (Email OTP / Magic Link)
+
+1. No [dashboard do Supabase](https://app.supabase.com/), acesse **Authentication > Providers**.
+2. Habilite **Email** e selecione **Magic Link** ou **OTP** conforme desejado.
+3. Configure o domínio de envio de e-mails ou utilize o serviço padrão do Supabase em ambiente de desenvolvimento.
+4. Atualize as variáveis `NEXT_PUBLIC_SUPABASE_URL` e `NEXT_PUBLIC_SUPABASE_ANON_KEY` com os valores do projeto.
+5. Para testar localmente, crie usuários via Magic Link ou usando o seed incluído (com emails `owner@example.com`, `leader@example.com`, etc.).
+
+## Variáveis de ambiente
+
+### Next.js (`.env.local`)
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=...        # URL do projeto Supabase
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...   # Chave pública (anon)
+SUPABASE_URL=...                    # Mesma URL para chamadas a Edge Functions
+SUPABASE_SERVICE_ROLE_KEY=...       # Chave service role (mantida somente no servidor)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+> **Atenção:** `SUPABASE_SERVICE_ROLE_KEY` nunca deve ser exposta ao cliente. Ela é utilizada exclusivamente em rotas servidoras para chamar Edge Functions.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Edge Functions (`supabase/functions/.env` ou variáveis de deploy)
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```env
+SUPABASE_URL=...
+SUPABASE_SERVICE_ROLE_KEY=...
+```
 
-## Learn More
+Quando publicar, configure as mesmas variáveis no Supabase para cada função.
 
-To learn more about Next.js, take a look at the following resources:
+## Fluxo funcional
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. **Criação de organização** (`POST /api/orgs/create`):
+   - Usuário autenticado chama a rota.
+   - Route handler contata a Edge Function `create_org`, que valida o slug, cria a organização e um membership `org` para o usuário.
+2. **Geração de convite** (`POST /api/invites/generate`):
+   - Somente `org` e `leader` ativos podem gerar convites para `leader` ou `rep`.
+   - Pode-se amarrar um novo `rep` a um líder específico (hierarquia) através de `parentLeaderId`.
+   - Edge Function `generate_invite` retorna apenas o token do convite; combine com sua URL pública para compartilhar.
+3. **Resgate de convite** (`POST /api/invites/redeem`):
+   - Usuário autenticado envia o token.
+   - Edge Function `redeem_invite` valida uso/expiração, cria (ou ajusta) o membership e incrementa `used_count`.
+   - A rota Next.js redireciona para `/app/:slug` da organização correspondente.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Cenários de teste de RLS
 
-## Deploy on Vercel
+Os dados seedados permitem validar a visibilidade no CRM (`public.contacts`):
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+1. **Representante (rep1@example.com):**
+   - Faça login como rep1 e tente listar contatos (`SELECT * FROM public.contacts`).
+   - Resultado esperado: apenas contatos com `owner_membership_id = cccc3333-cccc-3333-cccc-333333333333`.
+   - Tentar atualizar um contato pertencente a outro rep deve falhar (violação de política RLS).
+2. **Líder (leader@example.com):**
+   - Deve conseguir ver os próprios contatos (`owner_membership_id = bbbb2222-...`) e os contatos de seus reps subordinados (`cccc...` e `dddd...`).
+   - Inserir um novo contato para um rep subordinado é permitido desde que `owner_membership_id` pertença à subárvore.
+3. **Org owner (owner@example.com):**
+   - Consegue visualizar e inserir contatos para qualquer membership da organização.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Use o Supabase Studio com a opção **JWT override** ou tokens gerados via CLI (`supabase auth sign-in --email ...`) para simular cada usuário.
+
+## Boas práticas e segurança
+
+- Todas as mutações sensíveis (criação de organização, geração e resgate de convites) passam por Edge Functions com Service Role e validações de negócios.
+- RLS está habilitado em `memberships`, `contacts` e `invite_links`. Apenas leituras necessárias são liberadas aos usuários autenticados.
+- Função SQL `visible_membership_ids` calcula dinamicamente a subárvore de visibilidade, garantindo isolamento entre organizações e hierarquias.
+- Não exponha a Service Role key no cliente; somente rotas servidoras ou funções no backend devem utilizá-la.
+- Utilize HTTPS e configure domínios confiáveis de redirecionamento no Supabase para evitar abuso em convites.
+
+## Referências úteis
+
+- [Documentação do Supabase Auth](https://supabase.com/docs/guides/auth)
+- [RLS no Supabase](https://supabase.com/docs/guides/auth/row-level-security)
+- [Edge Functions](https://supabase.com/docs/guides/functions)
+- [Next.js App Router](https://nextjs.org/docs/app)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vibe/core": "^3.69.1",
+    "@supabase/ssr": "^0.4.0",
     "@vibe/icons": "^1.11.0",
     "clsx": "^2.1.1",
     "monday-ui-style": "^0.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.4.0
+        version: 0.4.1(@supabase/supabase-js@2.74.0)
       '@vibe/core':
         specifier: ^3.69.1
         version: 3.69.1(@babel/runtime@7.28.4)(@types/react@18.3.25)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(stylelint@14.16.1)
@@ -262,6 +265,38 @@ packages:
   '@popperjs/core@2.11.6':
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
 
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@supabase/auth-js@2.74.0':
+    resolution: {integrity: sha512-EJYDxYhBCOS40VJvfQ5zSjo8Ku7JbTICLTcmXt4xHMQZt4IumpRfHg11exXI9uZ6G7fhsQlNgbzDhFN4Ni9NnA==}
+
+  '@supabase/functions-js@2.74.0':
+    resolution: {integrity: sha512-VqWYa981t7xtIFVf7LRb9meklHckbH/tqwaML5P3LgvlaZHpoSPjMCNLcquuLYiJLxnh2rio7IxLh+VlvRvSWw==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@2.74.0':
+    resolution: {integrity: sha512-9Ypa2eS0Ib/YQClE+BhDSjx7OKjYEF6LAGjTB8X4HucdboGEwR0LZKctNfw6V0PPIAVjjzZxIlNBXGv0ypIkHw==}
+
+  '@supabase/realtime-js@2.74.0':
+    resolution: {integrity: sha512-K5VqpA4/7RO1u1nyD5ICFKzWKu58bIDcPxHY0aFA7MyWkFd0pzi/XYXeoSsAifnD9p72gPIpgxVXCQZKJg1ktQ==}
+
+  '@supabase/ssr@0.4.1':
+    resolution: {integrity: sha512-000i7y4ITXjXU0T1JytZYU33VbUNklX9YN47hCweaLKsTBAEigJJJCeq3G+/IiwEggBt58Vu0KQ3UGXON7OmDQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
+  '@supabase/storage-js@2.74.0':
+    resolution: {integrity: sha512-o0cTQdMqHh4ERDLtjUp1/KGPbQoNwKRxUh6f8+KQyjC5DSmiw/r+jgFe/WHh067aW+WU8nA9Ytw9ag7OhzxEkQ==}
+
+  '@supabase/supabase-js@2.74.0':
+    resolution: {integrity: sha512-IEMM/V6gKdP+N/X31KDIczVzghDpiPWFGLNjS8Rus71KvV6y6ueLrrE/JGCHDrU+9pq5copF3iCa0YQh+9Lq9Q==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -280,6 +315,9 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -290,6 +328,9 @@ packages:
 
   '@types/react@18.3.25':
     resolution: {integrity: sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vibe/core@3.69.1':
     resolution: {integrity: sha512-NQUcwz7pfZ8yNcK1xJTP/B4Rum5S/Kn0YyapRZmO9WtremSpnRmDmrfO5V034xZV7JeDijk90FtxMAyNJWWbhg==}
@@ -506,6 +547,10 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
   cosmiconfig@6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
@@ -1822,6 +1867,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -1910,6 +1958,12 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1949,6 +2003,18 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -2183,6 +2249,58 @@ snapshots:
 
   '@popperjs/core@2.11.6': {}
 
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    optional: true
+
+  '@supabase/auth-js@2.74.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.74.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@2.74.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.74.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.4.1(@supabase/supabase-js@2.74.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.74.0
+      cookie: 0.6.0
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+
+  '@supabase/storage-js@2.74.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.74.0':
+    dependencies:
+      '@supabase/auth-js': 2.74.0
+      '@supabase/functions-js': 2.74.0
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 2.74.0
+      '@supabase/realtime-js': 2.74.0
+      '@supabase/storage-js': 2.74.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.5':
@@ -2200,6 +2318,8 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.25)':
@@ -2210,6 +2330,10 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.19
 
   '@vibe/core@3.69.1(@babel/runtime@7.28.4)(@types/react@18.3.25)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(stylelint@14.16.1)':
     dependencies:
@@ -2473,6 +2597,8 @@ snapshots:
   consolidated-events@2.0.2: {}
 
   convert-source-map@1.9.0: {}
+
+  cookie@0.6.0: {}
 
   cosmiconfig@6.0.0:
     dependencies:
@@ -3994,6 +4120,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   trim-newlines@3.0.1: {}
 
   ts-interface-checker@0.1.13: {}
@@ -4084,6 +4212,13 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4151,6 +4286,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@8.18.3: {}
 
   yallist@4.0.0: {}
 

--- a/src/app/api/invites/generate/route.ts
+++ b/src/app/api/invites/generate/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const allowedRoles = new Set(["leader", "rep"]);
+
+export async function POST(request: NextRequest) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: "Server configuration missing" }, { status: 500 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    return NextResponse.json({ error: "Failed to retrieve session" }, { status: 500 });
+  }
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const organizationId = body.organizationId as string | undefined;
+  const roleToAssign = body.roleToAssign as string | undefined;
+  const parentLeaderId = body.parentLeaderId as string | undefined;
+  const maxUses = body.maxUses as number | undefined;
+  const expiresAt = body.expiresAt as string | undefined;
+
+  if (!organizationId || !roleToAssign) {
+    return NextResponse.json({ error: "organizationId and roleToAssign are required" }, { status: 422 });
+  }
+
+  if (!allowedRoles.has(roleToAssign)) {
+    return NextResponse.json({ error: "roleToAssign must be leader or rep" }, { status: 422 });
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("memberships")
+    .select("id, role, status")
+    .eq("organization_id", organizationId)
+    .eq("user_id", session.user.id)
+    .maybeSingle();
+
+  if (membershipError) {
+    return NextResponse.json({ error: "Failed to verify membership" }, { status: 500 });
+  }
+
+  if (!membership || membership.status !== "active") {
+    return NextResponse.json({ error: "Membership not found" }, { status: 404 });
+  }
+
+  if (membership.role !== "org" && membership.role !== "leader") {
+    return NextResponse.json({ error: "Only org or leader can generate invites" }, { status: 403 });
+  }
+
+  const generatedByMembershipId = (body.generatedByMembershipId as string | undefined) ?? membership.id;
+
+  if (generatedByMembershipId !== membership.id) {
+    return NextResponse.json({ error: "generatedByMembershipId must match the caller membership" }, { status: 403 });
+  }
+
+  const response = await fetch(`${supabaseUrl}/functions/v1/generate_invite`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      organizationId,
+      generatedByMembershipId,
+      roleToAssign,
+      parentLeaderId,
+      maxUses,
+      expiresAt,
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({ error: "Unknown error" }));
+
+  return NextResponse.json(payload, { status: response.status });
+}

--- a/src/app/api/invites/redeem/route.ts
+++ b/src/app/api/invites/redeem/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function POST(request: NextRequest) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: "Server configuration missing" }, { status: 500 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    return NextResponse.json({ error: "Failed to retrieve session" }, { status: 500 });
+  }
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const token = body.token as string | undefined;
+
+  if (!token) {
+    return NextResponse.json({ error: "token is required" }, { status: 422 });
+  }
+
+  const response = await fetch(`${supabaseUrl}/functions/v1/redeem_invite`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      token,
+      userId: session.user.id,
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({ error: "Unknown error" }));
+
+  if (!response.ok) {
+    return NextResponse.json(payload, { status: response.status });
+  }
+
+  const organizationId = payload.organizationId as string | undefined;
+
+  if (!organizationId) {
+    return NextResponse.json({ error: "Invalid response from invite redemption" }, { status: 500 });
+  }
+
+  const { data: organization, error: organizationError } = await supabase
+    .from("organizations")
+    .select("slug")
+    .eq("id", organizationId)
+    .single();
+
+  if (organizationError || !organization) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  const redirectUrl = new URL(`/app/${organization.slug}`, request.url);
+
+  return NextResponse.redirect(redirectUrl, { status: 303 });
+}

--- a/src/app/api/orgs/create/route.ts
+++ b/src/app/api/orgs/create/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function POST(request: NextRequest) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: "Server configuration missing" }, { status: 500 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    return NextResponse.json({ error: "Failed to retrieve session" }, { status: 500 });
+  }
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const response = await fetch(`${supabaseUrl}/functions/v1/create_org`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      ...body,
+      ownerUserId: session.user.id,
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({ error: "Unknown error" }));
+
+  return NextResponse.json(payload, { status: response.status });
+}

--- a/src/lib/org.ts
+++ b/src/lib/org.ts
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export type Organization = {
+  id: string;
+  slug: string;
+  name: string;
+  country: string;
+  created_by: string | null;
+  created_at: string;
+};
+
+export type Membership = {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  role: "org" | "leader" | "rep";
+  invited_by: string | null;
+  parent_leader_id: string | null;
+  status: string;
+  created_at: string;
+};
+
+export async function getOrgBySlug(slug: string): Promise<Organization> {
+  const supabase = createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from("organizations")
+    .select("id, slug, name, country, created_by, created_at")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    notFound();
+  }
+
+  return data;
+}
+
+export async function getMyMembership(orgId: string): Promise<Membership> {
+  const supabase = createSupabaseServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    notFound();
+  }
+
+  const { data, error } = await supabase
+    .from("memberships")
+    .select("id, organization_id, user_id, role, invited_by, parent_leader_id, status, created_at")
+    .eq("organization_id", orgId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    notFound();
+  }
+
+  if (data.status !== "active") {
+    notFound();
+  }
+
+  return data as Membership;
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createSupabaseBrowserClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables");
+  }
+
+  return createBrowserClient(supabaseUrl, supabaseAnonKey);
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+
+export function createSupabaseServerClient() {
+  const cookieStore = cookies();
+  const canSet = typeof (cookieStore as unknown as { set?: unknown }).set === "function";
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables");
+  }
+
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set(name: string, value: string, options?: Record<string, unknown>) {
+        if (!canSet) return;
+        (cookieStore as unknown as { set: (args: Record<string, unknown>) => void }).set({
+          name,
+          value,
+          ...(options ?? {}),
+        });
+      },
+      remove(name: string, options?: Record<string, unknown>) {
+        if (!canSet) return;
+        (cookieStore as unknown as { set: (args: Record<string, unknown>) => void }).set({
+          name,
+          value: "",
+          ...(options ?? {}),
+          expires: new Date(0),
+        });
+      },
+    },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables");
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return request.cookies.get(name)?.value;
+      },
+      set(name: string, value: string, options?: Record<string, unknown>) {
+        response.cookies.set({ name, value, ...(options ?? {}) });
+      },
+      remove(name: string, options?: Record<string, unknown>) {
+        response.cookies.set({ name, value: "", ...(options ?? {}), expires: new Date(0) });
+      },
+    },
+  });
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/sign-in";
+    redirectUrl.searchParams.set("redirectTo", request.nextUrl.pathname + request.nextUrl.search);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/app/:path*"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+
+async function validateSession(accessToken: string, supabaseUrl: string, supabaseAnonKey: string) {
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      apikey: supabaseAnonKey,
+    },
+    cache: "no-store",
+  });
+
+  if (response.ok) {
+    return true;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return false;
+  }
+
+  throw new Error(`Unexpected response when validating Supabase session: ${response.status}`);
+}
 
 export async function middleware(request: NextRequest) {
-  const response = NextResponse.next();
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -10,32 +29,25 @@ export async function middleware(request: NextRequest) {
     throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables");
   }
 
-  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      get(name: string) {
-        return request.cookies.get(name)?.value;
-      },
-      set(name: string, value: string, options?: Record<string, unknown>) {
-        response.cookies.set({ name, value, ...(options ?? {}) });
-      },
-      remove(name: string, options?: Record<string, unknown>) {
-        response.cookies.set({ name, value: "", ...(options ?? {}), expires: new Date(0) });
-      },
-    },
-  });
+  const accessToken = request.cookies.get("sb-access-token")?.value;
 
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
+  if (!accessToken) {
     const redirectUrl = request.nextUrl.clone();
     redirectUrl.pathname = "/sign-in";
     redirectUrl.searchParams.set("redirectTo", request.nextUrl.pathname + request.nextUrl.search);
     return NextResponse.redirect(redirectUrl);
   }
 
-  return response;
+  const isValid = await validateSession(accessToken, supabaseUrl, supabaseAnonKey);
+
+  if (!isValid) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/sign-in";
+    redirectUrl.searchParams.set("redirectTo", request.nextUrl.pathname + request.nextUrl.search);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {

--- a/supabase/functions/create_org/index.ts
+++ b/supabase/functions/create_org/index.ts
@@ -1,0 +1,125 @@
+import { serve } from "std/http/server";
+import { createClient } from "@supabase/supabase-js";
+
+type CreateOrgBody = {
+  slug: string;
+  name: string;
+  country?: string;
+  ownerUserId: string;
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables");
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+function normalizeSlug(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  let body: CreateOrgBody;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { slug, name, country, ownerUserId } = body ?? {};
+  if (!slug || !name || !ownerUserId) {
+    return new Response(JSON.stringify({ error: "slug, name and ownerUserId are required" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const normalizedSlug = normalizeSlug(slug);
+  if (!normalizedSlug) {
+    return new Response(JSON.stringify({ error: "slug is invalid after normalization" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const existing = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("slug", normalizedSlug)
+    .maybeSingle();
+
+  if (existing.error) {
+    console.error(existing.error);
+    return new Response(JSON.stringify({ error: "Failed to verify organization slug" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (existing.data) {
+    return new Response(JSON.stringify({ error: "Organization slug already exists" }), {
+      status: 409,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { data: organization, error: orgError } = await supabase
+    .from("organizations")
+    .insert({
+      slug: normalizedSlug,
+      name,
+      country: country ?? "BR",
+      created_by: ownerUserId,
+    })
+    .select("*")
+    .single();
+
+  if (orgError || !organization) {
+    console.error(orgError);
+    return new Response(JSON.stringify({ error: "Failed to create organization" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("memberships")
+    .insert({
+      organization_id: organization.id,
+      user_id: ownerUserId,
+      role: "org",
+      status: "active",
+    })
+    .select("*")
+    .single();
+
+  if (membershipError || !membership) {
+    console.error(membershipError);
+    return new Response(JSON.stringify({ error: "Failed to create owner membership" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ organization, membership }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/generate_invite/index.ts
+++ b/supabase/functions/generate_invite/index.ts
@@ -1,0 +1,184 @@
+import { serve } from "std/http/server";
+import { createClient } from "@supabase/supabase-js";
+
+type GenerateInviteBody = {
+  organizationId: string;
+  generatedByMembershipId: string;
+  roleToAssign: "leader" | "rep";
+  parentLeaderId?: string;
+  maxUses?: number;
+  expiresAt?: string;
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables");
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+function generateToken(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  let body: GenerateInviteBody;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { organizationId, generatedByMembershipId, roleToAssign, parentLeaderId, maxUses, expiresAt } = body ?? {};
+
+  if (!organizationId || !generatedByMembershipId || !roleToAssign) {
+    return new Response(JSON.stringify({ error: "organizationId, generatedByMembershipId and roleToAssign are required" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (roleToAssign !== "leader" && roleToAssign !== "rep") {
+    return new Response(JSON.stringify({ error: "roleToAssign must be leader or rep" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { data: generator, error: generatorError } = await supabase
+    .from("memberships")
+    .select("id, organization_id, role, status")
+    .eq("id", generatedByMembershipId)
+    .eq("organization_id", organizationId)
+    .single();
+
+  if (generatorError || !generator) {
+    console.error(generatorError);
+    return new Response(JSON.stringify({ error: "Generator membership not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (generator.status !== "active") {
+    return new Response(JSON.stringify({ error: "Membership is not active" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (generator.role !== "org" && generator.role !== "leader") {
+    return new Response(JSON.stringify({ error: "Only org or leader can generate invites" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let resolvedParentLeaderId: string | null = null;
+  if (parentLeaderId) {
+    const { data: parent, error: parentError } = await supabase
+      .from("memberships")
+      .select("id, organization_id, role, status")
+      .eq("id", parentLeaderId)
+      .maybeSingle();
+
+    if (parentError) {
+      console.error(parentError);
+      return new Response(JSON.stringify({ error: "Failed to validate parent leader" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!parent || parent.organization_id !== organizationId) {
+      return new Response(JSON.stringify({ error: "parentLeaderId must belong to the same organization" }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (parent.role !== "leader" || parent.status !== "active") {
+      return new Response(JSON.stringify({ error: "parentLeaderId must reference an active leader" }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (roleToAssign === "leader") {
+      return new Response(JSON.stringify({ error: "parentLeaderId cannot be provided when inviting a leader" }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (generator.role === "leader" && parent.id !== generator.id) {
+      return new Response(JSON.stringify({ error: "Leaders can only assign reps to themselves" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    resolvedParentLeaderId = parent.id;
+  } else if (roleToAssign === "rep" && generator.role === "leader") {
+    resolvedParentLeaderId = generator.id;
+  }
+
+  if (typeof maxUses !== "undefined" && (!Number.isInteger(maxUses) || maxUses <= 0)) {
+    return new Response(JSON.stringify({ error: "maxUses must be a positive integer" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let expiresAtIso: string | null = null;
+  if (expiresAt) {
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return new Response(JSON.stringify({ error: "expiresAt must be a valid date" }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    expiresAtIso = parsed.toISOString();
+  }
+
+  const token = generateToken();
+
+  const { data: invite, error: inviteError } = await supabase
+    .from("invite_links")
+    .insert({
+      organization_id: organizationId,
+      generated_by_membership_id: generatedByMembershipId,
+      role_to_assign: roleToAssign,
+      parent_leader_id: resolvedParentLeaderId,
+      token,
+      max_uses: maxUses ?? 1,
+      expires_at: expiresAtIso,
+    })
+    .select("token")
+    .single();
+
+  if (inviteError || !invite) {
+    console.error(inviteError);
+    return new Response(JSON.stringify({ error: "Failed to generate invite" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ token: invite.token }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.44.2",
+    "std/http/server": "https://deno.land/std@0.208.0/http/server.ts"
+  }
+}

--- a/supabase/functions/redeem_invite/index.ts
+++ b/supabase/functions/redeem_invite/index.ts
@@ -1,0 +1,175 @@
+import { serve } from "std/http/server";
+import { createClient } from "@supabase/supabase-js";
+
+type RedeemInviteBody = {
+  token: string;
+  userId: string;
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables");
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  let body: RedeemInviteBody;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { token, userId } = body ?? {};
+  if (!token || !userId) {
+    return new Response(JSON.stringify({ error: "token and userId are required" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { data: invite, error: inviteError } = await supabase
+    .from("invite_links")
+    .select("id, organization_id, generated_by_membership_id, role_to_assign, parent_leader_id, max_uses, used_count, expires_at")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (inviteError) {
+    console.error(inviteError);
+    return new Response(JSON.stringify({ error: "Failed to lookup invite" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!invite) {
+    return new Response(JSON.stringify({ error: "Invite not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (invite.expires_at && new Date(invite.expires_at).getTime() < Date.now()) {
+    return new Response(JSON.stringify({ error: "Invite has expired" }), {
+      status: 410,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (invite.used_count >= invite.max_uses) {
+    return new Response(JSON.stringify({ error: "Invite has been fully redeemed" }), {
+      status: 409,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { data: existingMembership, error: existingMembershipError } = await supabase
+    .from("memberships")
+    .select("id, role, status, parent_leader_id, invited_by")
+    .eq("organization_id", invite.organization_id)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (existingMembershipError) {
+    console.error(existingMembershipError);
+    return new Response(JSON.stringify({ error: "Failed to check existing membership" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const updates: Record<string, unknown> = {};
+  const desiredParentLeaderId = invite.role_to_assign === "rep" ? invite.parent_leader_id ?? null : null;
+  let membershipId: string;
+
+  if (existingMembership) {
+    membershipId = existingMembership.id;
+    if (existingMembership.role !== invite.role_to_assign) {
+      updates.role = invite.role_to_assign;
+    }
+    if ((existingMembership.parent_leader_id ?? null) !== desiredParentLeaderId) {
+      updates.parent_leader_id = desiredParentLeaderId;
+    }
+    if (existingMembership.status !== "active") {
+      updates.status = "active";
+    }
+    if (!existingMembership.invited_by) {
+      updates.invited_by = invite.generated_by_membership_id;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      const { error: updateError } = await supabase
+        .from("memberships")
+        .update(updates)
+        .eq("id", existingMembership.id);
+
+      if (updateError) {
+        console.error(updateError);
+        return new Response(JSON.stringify({ error: "Failed to update membership" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+  } else {
+    const { data: newMembership, error: membershipError } = await supabase
+      .from("memberships")
+      .insert({
+        organization_id: invite.organization_id,
+        user_id: userId,
+        role: invite.role_to_assign,
+        parent_leader_id: desiredParentLeaderId,
+        invited_by: invite.generated_by_membership_id,
+        status: "active",
+      })
+      .select("id")
+      .single();
+
+    if (membershipError || !newMembership) {
+      console.error(membershipError);
+      return new Response(JSON.stringify({ error: "Failed to create membership" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    membershipId = newMembership.id;
+  }
+
+  const { error: incrementError } = await supabase
+    .from("invite_links")
+    .update({ used_count: invite.used_count + 1 })
+    .eq("id", invite.id);
+
+  if (incrementError) {
+    console.error(incrementError);
+    return new Response(JSON.stringify({ error: "Failed to update invite usage" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      organizationId: invite.organization_id,
+      membershipId,
+      role: invite.role_to_assign,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+});

--- a/supabase/migrations/000_auth_roles_contacts.sql
+++ b/supabase/migrations/000_auth_roles_contacts.sql
@@ -1,0 +1,266 @@
+-- Ensure search_path is safe
+SET search_path = public, pg_temp;
+
+-- Roles enum
+CREATE TYPE public.role AS ENUM ('org', 'leader', 'rep');
+
+-- Contact status enum
+CREATE TYPE public.status AS ENUM ('novo', 'qualificado', 'contatado', 'followup', 'ganho', 'perdido');
+
+-- Mirror auth.users
+CREATE TABLE public.profiles (
+    id uuid PRIMARY KEY,
+    email text,
+    raw_user_meta_data jsonb,
+    created_at timestamptz DEFAULT timezone('utc'::text, now())
+);
+
+COMMENT ON TABLE public.profiles IS 'Mirror table for auth.users to simplify joins under RLS.';
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    INSERT INTO public.profiles (id, email, raw_user_meta_data, created_at)
+    VALUES (NEW.id, NEW.email, NEW.raw_user_meta_data, timezone('utc'::text, now()))
+    ON CONFLICT (id) DO UPDATE
+    SET email = EXCLUDED.email,
+        raw_user_meta_data = EXCLUDED.raw_user_meta_data;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+-- Organizations
+CREATE TABLE public.organizations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug text NOT NULL UNIQUE,
+    name text NOT NULL,
+    country text NOT NULL DEFAULT 'BR',
+    created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+COMMENT ON COLUMN public.organizations.slug IS 'Unique slug used in URLs.';
+
+-- Memberships
+CREATE TABLE public.memberships (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    role public.role NOT NULL,
+    invited_by uuid REFERENCES public.memberships(id) ON DELETE SET NULL,
+    parent_leader_id uuid REFERENCES public.memberships(id) ON DELETE SET NULL,
+    status text NOT NULL DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    CONSTRAINT memberships_parent_leader_role CHECK (
+        parent_leader_id IS NULL OR role = 'rep'
+    )
+);
+
+ALTER TABLE public.memberships
+ADD CONSTRAINT memberships_unique_user_per_org UNIQUE (organization_id, user_id);
+
+CREATE INDEX memberships_org_idx ON public.memberships (organization_id);
+CREATE INDEX memberships_user_idx ON public.memberships (user_id);
+CREATE INDEX memberships_invited_by_idx ON public.memberships (invited_by);
+CREATE INDEX memberships_parent_leader_idx ON public.memberships (parent_leader_id);
+CREATE UNIQUE INDEX memberships_org_id_idx ON public.memberships (organization_id, id);
+
+ALTER TABLE public.memberships
+ADD CONSTRAINT memberships_parent_same_org FOREIGN KEY (organization_id, parent_leader_id)
+REFERENCES public.memberships (organization_id, id);
+
+COMMENT ON COLUMN public.memberships.parent_leader_id IS 'Links reps to their leader membership for hierarchy traversal.';
+
+-- Contacts
+CREATE TABLE public.contacts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+    owner_membership_id uuid NOT NULL REFERENCES public.memberships(id) ON DELETE CASCADE,
+    name text NOT NULL,
+    email text,
+    whatsapp text,
+    city text,
+    uf text,
+    source text,
+    tags text[] DEFAULT ARRAY[]::text[],
+    status public.status NOT NULL DEFAULT 'novo',
+    last_touch_at timestamptz,
+    next_action_at timestamptz,
+    notes text,
+    invited_by uuid REFERENCES public.memberships(id) ON DELETE SET NULL,
+    avatar text,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+CREATE INDEX contacts_org_idx ON public.contacts (organization_id);
+CREATE INDEX contacts_owner_idx ON public.contacts (owner_membership_id);
+CREATE INDEX contacts_status_idx ON public.contacts (status);
+CREATE INDEX contacts_org_owner_status_idx ON public.contacts (organization_id, owner_membership_id, status);
+CREATE INDEX contacts_tags_gin_idx ON public.contacts USING GIN (tags);
+
+CREATE OR REPLACE FUNCTION public.set_contacts_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    NEW.updated_at = timezone('utc'::text, now());
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER contacts_updated_at
+BEFORE UPDATE ON public.contacts
+FOR EACH ROW
+EXECUTE FUNCTION public.set_contacts_updated_at();
+
+-- Invite links
+CREATE TABLE public.invite_links (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+    generated_by_membership_id uuid NOT NULL REFERENCES public.memberships(id) ON DELETE CASCADE,
+    role_to_assign public.role NOT NULL,
+    parent_leader_id uuid REFERENCES public.memberships(id) ON DELETE SET NULL,
+    token text NOT NULL UNIQUE,
+    max_uses integer NOT NULL DEFAULT 1 CHECK (max_uses > 0),
+    used_count integer NOT NULL DEFAULT 0 CHECK (used_count >= 0),
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    CONSTRAINT invite_links_role_check CHECK (role_to_assign IN ('leader', 'rep'))
+);
+
+CREATE INDEX invite_links_org_idx ON public.invite_links (organization_id);
+CREATE INDEX invite_links_token_idx ON public.invite_links (token);
+
+-- Helper function to compute membership visibility
+CREATE OR REPLACE FUNCTION public.visible_membership_ids(org_id uuid)
+RETURNS TABLE(membership_id uuid)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+WITH current_member AS (
+    SELECT id, role
+    FROM public.memberships
+    WHERE organization_id = org_id
+      AND user_id = auth.uid()
+      AND status = 'active'
+),
+recursive_tree AS (
+    SELECT m.id, m.parent_leader_id, m.role
+    FROM public.memberships m
+    JOIN current_member cm ON m.id = cm.id
+    WHERE m.status = 'active'
+  UNION ALL
+    SELECT child.id, child.parent_leader_id, child.role
+    FROM public.memberships child
+    JOIN recursive_tree rt ON child.parent_leader_id = rt.id
+    WHERE child.status = 'active'
+)
+SELECT m.id AS membership_id
+FROM public.memberships m
+JOIN current_member cm ON TRUE
+WHERE m.organization_id = org_id
+  AND m.status = 'active'
+  AND (
+        cm.role = 'org'
+        OR (cm.role = 'leader' AND m.id IN (SELECT id FROM recursive_tree))
+        OR (cm.role = 'rep' AND m.id = cm.id)
+      );
+$$;
+
+COMMENT ON FUNCTION public.visible_membership_ids IS 'Returns membership ids visible to the current user within an organization based on hierarchy.';
+
+-- Enable RLS and policies
+ALTER TABLE public.memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.invite_links ENABLE ROW LEVEL SECURITY;
+
+-- memberships policies
+CREATE POLICY memberships_select_self
+ON public.memberships
+FOR SELECT
+USING (user_id = auth.uid());
+
+CREATE POLICY memberships_select_org
+ON public.memberships
+FOR SELECT
+USING (
+    EXISTS (
+        SELECT 1
+        FROM public.memberships m2
+        WHERE m2.organization_id = memberships.organization_id
+          AND m2.user_id = auth.uid()
+          AND m2.role = 'org'
+          AND m2.status = 'active'
+    )
+);
+
+-- invite_links policies
+CREATE POLICY invite_links_select_generators
+ON public.invite_links
+FOR SELECT
+USING (
+    generated_by_membership_id IN (
+        SELECT membership_id FROM public.visible_membership_ids(invite_links.organization_id)
+    )
+);
+
+CREATE POLICY invite_links_select_org
+ON public.invite_links
+FOR SELECT
+USING (
+    EXISTS (
+        SELECT 1
+        FROM public.memberships m2
+        WHERE m2.organization_id = invite_links.organization_id
+          AND m2.user_id = auth.uid()
+          AND m2.role = 'org'
+          AND m2.status = 'active'
+    )
+);
+
+-- contacts policies
+CREATE POLICY contacts_select_visible
+ON public.contacts
+FOR SELECT
+USING (
+    owner_membership_id IN (
+        SELECT membership_id FROM public.visible_membership_ids(contacts.organization_id)
+    )
+);
+
+CREATE POLICY contacts_insert_visible
+ON public.contacts
+FOR INSERT
+WITH CHECK (
+    owner_membership_id IN (
+        SELECT membership_id FROM public.visible_membership_ids(contacts.organization_id)
+    )
+);
+
+CREATE POLICY contacts_update_visible
+ON public.contacts
+FOR UPDATE
+USING (
+    owner_membership_id IN (
+        SELECT membership_id FROM public.visible_membership_ids(contacts.organization_id)
+    )
+)
+WITH CHECK (
+    owner_membership_id IN (
+        SELECT membership_id FROM public.visible_membership_ids(contacts.organization_id)
+    )
+);
+

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,65 @@
+-- Seed data for local development
+SET search_path = public, pg_temp;
+
+-- Create demo users in auth schema (passwordless, for local testing only)
+INSERT INTO auth.users (id, email, raw_user_meta_data, raw_app_meta_data)
+VALUES
+  ('11111111-1111-1111-1111-111111111111', 'owner@example.com', '{"name": "Org Owner"}', '{"provider": "email"}'),
+  ('22222222-2222-2222-2222-222222222222', 'leader@example.com', '{"name": "Top Leader"}', '{"provider": "email"}'),
+  ('33333333-3333-3333-3333-333333333333', 'rep1@example.com', '{"name": "Rep One"}', '{"provider": "email"}'),
+  ('44444444-4444-4444-4444-444444444444', 'rep2@example.com', '{"name": "Rep Two"}', '{"provider": "email"}')
+ON CONFLICT (id) DO NOTHING;
+
+-- Organization
+INSERT INTO public.organizations (id, slug, name, country, created_by)
+VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'acme', 'ACME Marketing', 'BR', '11111111-1111-1111-1111-111111111111')
+ON CONFLICT (id) DO NOTHING;
+
+-- Memberships hierarchy
+INSERT INTO public.memberships (id, organization_id, user_id, role, status)
+VALUES
+  ('aaaa1111-aaaa-1111-aaaa-111111111111', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'org', 'active'),
+  ('bbbb2222-bbbb-2222-bbbb-222222222222', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'leader', 'active'),
+  ('cccc3333-cccc-3333-cccc-333333333333', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '33333333-3333-3333-3333-333333333333', 'rep', 'active'),
+  ('dddd4444-dddd-4444-dddd-444444444444', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '44444444-4444-4444-4444-444444444444', 'rep', 'active')
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE public.memberships
+SET parent_leader_id = 'bbbb2222-bbbb-2222-bbbb-222222222222'
+WHERE id IN ('cccc3333-cccc-3333-cccc-333333333333', 'dddd4444-dddd-4444-dddd-444444444444');
+
+-- Contacts distributed across memberships
+INSERT INTO public.contacts (
+  id,
+  organization_id,
+  owner_membership_id,
+  name,
+  email,
+  whatsapp,
+  city,
+  uf,
+  source,
+  tags,
+  status,
+  invited_by,
+  notes,
+  last_touch_at,
+  next_action_at
+) VALUES
+  ('10000000-0000-0000-0000-000000000001', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'aaaa1111-aaaa-1111-aaaa-111111111111', 'Maria Lima', 'maria@clientes.com', '+55 11 90000-0001', 'São Paulo', 'SP', 'webinar', ARRAY['vip','sp'], 'qualificado', NULL, 'Cliente premium em potencial', timezone('utc', now()) - interval '7 days', timezone('utc', now()) + interval '3 days'),
+  ('10000000-0000-0000-0000-000000000002', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'aaaa1111-aaaa-1111-aaaa-111111111111', 'João Pedro', 'joao@clientes.com', '+55 11 90000-0002', 'Campinas', 'SP', 'indicação', ARRAY['org'], 'contatado', NULL, NULL, timezone('utc', now()) - interval '2 days', timezone('utc', now()) + interval '5 days'),
+  ('10000000-0000-0000-0000-000000000003', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Ana Souza', 'ana@clientes.com', '+55 21 90000-0003', 'Rio de Janeiro', 'RJ', 'evento', ARRAY['top'], 'followup', 'aaaa1111-aaaa-1111-aaaa-111111111111', 'Aguardando retorno pós evento', timezone('utc', now()) - interval '1 day', timezone('utc', now()) + interval '2 days'),
+  ('10000000-0000-0000-0000-000000000004', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Carlos Dias', 'carlos@clientes.com', '+55 31 90000-0004', 'Belo Horizonte', 'MG', 'facebook', ARRAY['mineiro'], 'contatado', NULL, NULL, timezone('utc', now()) - interval '4 days', timezone('utc', now()) + interval '4 days'),
+  ('10000000-0000-0000-0000-000000000005', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'cccc3333-cccc-3333-cccc-333333333333', 'Fernanda Alves', 'fernanda@clientes.com', '+55 41 90000-0005', 'Curitiba', 'PR', 'instagram', ARRAY['lead-frio'], 'novo', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Requer aquecimento inicial', NULL, timezone('utc', now()) + interval '6 days'),
+  ('10000000-0000-0000-0000-000000000006', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'cccc3333-cccc-3333-cccc-333333333333', 'Gustavo Nunes', 'gustavo@clientes.com', '+55 21 90000-0006', 'Niterói', 'RJ', 'indicação', ARRAY['quente'], 'qualificado', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Pronto para apresentação', timezone('utc', now()) - interval '3 days', timezone('utc', now()) + interval '1 day'),
+  ('10000000-0000-0000-0000-000000000007', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'dddd4444-dddd-4444-dddd-444444444444', 'Helena Prado', 'helena@clientes.com', '+55 71 90000-0007', 'Salvador', 'BA', 'facebook', ARRAY['ba'], 'contatado', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Enviado material inicial', timezone('utc', now()) - interval '5 days', timezone('utc', now()) + interval '7 days'),
+  ('10000000-0000-0000-0000-000000000008', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'dddd4444-dddd-4444-dddd-444444444444', 'Igor Silva', 'igor@clientes.com', '+55 81 90000-0008', 'Recife', 'PE', 'webinar', ARRAY['nordeste'], 'followup', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Agendar call de alinhamento', timezone('utc', now()) - interval '6 days', timezone('utc', now()) + interval '2 days'),
+  ('10000000-0000-0000-0000-000000000009', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Julia Castro', 'julia@clientes.com', '+55 48 90000-0009', 'Florianópolis', 'SC', 'linkedin', ARRAY['sul'], 'ganho', 'aaaa1111-aaaa-1111-aaaa-111111111111', 'Fechou contrato', timezone('utc', now()) - interval '15 days', timezone('utc', now()) + interval '14 days'),
+  ('10000000-0000-0000-0000-000000000010', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'cccc3333-cccc-3333-cccc-333333333333', 'Kleber Ramos', 'kleber@clientes.com', '+55 62 90000-0010', 'Goiânia', 'GO', 'indicação', ARRAY['follow'], 'perdido', 'bbbb2222-bbbb-2222-bbbb-222222222222', 'Preferiu concorrente', timezone('utc', now()) - interval '10 days', timezone('utc', now()) + interval '9 days')
+ON CONFLICT (id) DO NOTHING;
+
+-- Guidance for testing RLS scenarios locally
+-- Use supabase start then supabase login; run `supabase functions serve` or JWT overrides in Supabase Studio.
+-- You can simulate each role by issuing a JWT with the corresponding user id above (owner, leader, rep1, rep2).
+-- With auth.uid() set to leader (2222...), verify that SELECT on public.contacts returns their contacts plus reps in the hierarchy.
+-- With auth.uid() set to rep1 (3333...), ensure they cannot read or update contacts owned by rep2 (4444...).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "supabase/functions"
   ]
 }


### PR DESCRIPTION
## Summary
- add Supabase SQL schema for organizations, memberships, contacts, invite links and supporting RLS policies
- implement edge functions for creating orgs, generating invites, and redeeming invites using the service role
- wire Next.js middleware, Supabase helpers, and API routes to call edge functions and document setup with seeds and README guidance

## Testing
- `pnpm lint` *(fails: command prompts for interactive ESLint setup in this template)*

------
https://chatgpt.com/codex/tasks/task_e_68e51310a7388324819062d3d7d58722