### PR TITLE
Fix Supabase callback fallback and membership policy recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+# 2025-11-02
+
+### Fixed
+- `/auth/callback` agora tenta primeiro `getSessionFromUrl(storeSession: true)` para recuperar sessões PKCE/implicit, faz fallback para `verifyOtp` tolerante a tipos (`magiclink`, `signup`, `email`, `invite`, `recovery`) e só recorre a `setSession` com tokens do hash quando necessário, evitando os erros "Link inválido ou expirado" após login ou cadastro.
+- Criamos a função `can_access_membership` (security definer) e substituímos a policy recursiva por `memberships_select_visible`, eliminando o erro `42P17 infinite recursion detected in policy for relation "memberships"` ao carregar o dashboard.
+
+### Documentation
+- README e `docs/dev_setup_crm.md` atualizados com a nova ordem do callback (`getSessionFromUrl` + fallback OTP) e a nota sobre `can_access_membership` para mitigar recursão de RLS.
+
+# 2025-11-01
+
+### Fixed
+- Corrigimos o callback `/auth/callback` para priorizar `verifyOtp` com `token`/`token_hash`, sincronizar cookies apenas após uma sessão válida e limpar o hash da URL antes de redirecionar, evitando erros de "link expirado".
+
+### Added
+- Automatizamos a criação de organizações e memberships com papel `org` para novos usuários através do gatilho `handle_new_user`, além de remover perfis órfãos com o novo gatilho `handle_deleted_user`.
+
+### Documentation
+- README e `docs/dev_setup_crm.md` atualizados com o fluxo revisado do callback, a atribuição automática de organizações e as regras para remoção de perfis quando usuários são excluídos.
+
+# 2025-10-31
+
+### Fixed
+- Reestruturamos `/auth/callback` para processar manualmente `code`, `token_hash` e tokens `access/refresh`, tolerando erros de PKCE e impedindo que o magic link expire ao chegar ao usuário.
+
+### Changed
+- O cliente Supabase no browser agora mantém `detectSessionInUrl` desativado, entregando ao callback o tratamento dos parâmetros e evitando que o SDK consuma o token antes da sincronização de cookies.
+
+### Documentation
+- README e `docs/dev_setup_crm.md` atualizados com o passo a passo do callback manual, incluindo fallback PKCE/OTP e dicas de troubleshooting para links abertos em outro dispositivo.
+
+# 2025-10-30
+
+### Fixed
+- Corrigimos o callback de autenticação para aguardar `supabase.auth.initialize()`, reaproveitar a sessão detectada automaticamente e validar tokens legados com `verifyOtp`, eliminando o erro "code verifier" e os loops de retorno ao `/sign-in`.
+
+### Changed
+- Middleware agora usa `createServerClient` para validar usuários autenticados e propagar cookies do Supabase, substituindo o fetch manual que ignorava os cookies PKCE.
+
+### Documentation
+- Atualizamos o guia de login para detalhar a ordem do callback (inicialização, validação de sessão, fallback `token_hash`, sincronização) e registrar o novo middleware baseado no cliente do Supabase.
+
+# 2025-10-29
+
+### Fixed
+- Fluxo de callback do Supabase realiza `exchangeCodeForSession` ao receber `code` de PKCE e mantém o fallback de `token_hash`, evitando que os usuários sejam redirecionados de volta para `/sign-in` após clicar no magic link.
+
+### Changed
+- Formulário de login respeita o parâmetro `redirectTo` recebido via query string e gera `emailRedirectTo` usando `NEXT_PUBLIC_SITE_URL`, suportando múltiplos ambientes sem alterar o código.
+
+### Documentation
+- README e `docs/dev_setup_crm.md` atualizados com a variável `NEXT_PUBLIC_SITE_URL` e a descrição do fluxo de troca PKCE no callback.
+
 # 2025-10-28
 
 ### Added
@@ -65,3 +118,9 @@
 
 ### Documentation
 - README atualizado com instruções para configurar e testar o fluxo de login via Magic Link.
+## 2025-10-15
+
+### Fixed
+- Corrigimos a troca de código PKCE em `/auth/callback` para usar a assinatura correta de `exchangeCodeForSession`, evitando falhas de build no fluxo de login por Magic Link.
+- Quando o Supabase não encontra `code_verifier` (ex.: link aberto em outro dispositivo), o callback agora ignora o erro e cai no `token_hash`, evitando o loop de autenticação ao validar magic links.
+

--- a/docs/dev_setup_crm.md
+++ b/docs/dev_setup_crm.md
@@ -7,6 +7,7 @@
   ```env
   NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
   NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+  NEXT_PUBLIC_SITE_URL=http://localhost:3000
   SUPABASE_URL=http://127.0.0.1:54321
   SUPABASE_SERVICE_ROLE_KEY=...
   ```
@@ -29,6 +30,11 @@ pnpm install
 pnpm dev
 ```
 A aplicação fica disponível em `http://localhost:3000`. Usuários seed: `owner@example.com`, `leader@example.com`, `rep1@example.com`, `rep2@example.com` (login via magic link/OTP).
+> **Fluxo de login:** o callback `/auth/callback` chama `getSessionFromUrl(storeSession: true)` para reaproveitar códigos PKCE ou tokens do hash; se faltar `code_verifier`, cai para `verifyOtp` com tolerância aos tipos (`magiclink`, `signup`, `email`, `invite`, `recovery`) e, em último caso, aceita `setSession` com `access_token`/`refresh_token`. Só depois sincroniza os cookies via `/auth/sync`. O middleware (`src/middleware.ts`) segue delegando a validação ao `createServerClient`, preservando os cookies emitidos pelo Supabase.
+
+> **Políticas RLS:** a função `can_access_membership` (security definer) garante que `memberships_select_visible` resolva visibilidade sem recursão infinita ao consultar `visible_membership_ids`, evitando o erro `42P17` observado quando policies acessam a própria tabela diretamente.
+
+> **Onboarding automático:** o gatilho SQL `handle_new_user` cria uma organização padrão e um membership `org` para cada usuário novo, além de espelhar os metadados em `public.profiles`. Ao remover um usuário em `auth.users`, o gatilho `handle_deleted_user` limpa o respectivo perfil.
 
 ## 5. Scripts úteis
 | Script | Descrição |

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,46 +3,208 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { Flex, Loader, Text } from "@vibe/core";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
 export default function AuthCallbackPage() {
-  const sp = useSearchParams();
-  const redirectTo = sp.get("redirectTo")?.startsWith("/") ? sp.get("redirectTo")! : "/dashboard";
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo")?.startsWith("/") ? searchParams.get("redirectTo")! : "/dashboard";
   const supabase = useMemo(() => createSupabaseBrowserClient(), []);
   const [err, setErr] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(true);
 
   useEffect(() => {
-    const run = async () => {
-      // 1) implicit: detectSessionInUrl=true salva sessão se veio #access_token
-      await supabase.auth.getSession();
+    let cancelled = false;
 
-      // 2) fallback token_hash (alguns templates enviam magic link assim)
-      const u = new URL(window.location.href);
-      const hash = new URLSearchParams(location.hash.slice(1));
-      const token_hash = u.searchParams.get("token_hash") || hash.get("token_hash");
-      if (token_hash) {
-        const { error } = await supabase.auth.verifyOtp({ type: "magiclink", token_hash });
-        if (error) { setErr(error.message); return; }
+    const surfaceError = (message: string) => {
+      if (!cancelled) {
+        setErr(message);
+        setProcessing(false);
       }
-
-      // 3) sincroniza cookies HTTP-only p/ middleware
-      const { data } = await supabase.auth.getSession();
-      const at = data.session?.access_token;
-      const rt = data.session?.refresh_token;
-      if (!at || !rt) { setErr("Link inválido."); return; }
-
-      const r = await fetch("/auth/sync", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ access_token: at, refresh_token: rt }),
-        cache: "no-store",
-      });
-      if (!r.ok) { setErr(await r.text().catch(()=> "Falha ao sincronizar.")); return; }
-
-      window.location.replace(redirectTo);
     };
+
+    const run = async () => {
+      try {
+        const url = new URL(window.location.href);
+        const search = url.searchParams;
+        const hash = new URLSearchParams(url.hash.replace(/^#/, ""));
+        const pickParam = (key: string) => search.get(key) ?? hash.get(key);
+
+        const errorDescription = pickParam("error_description") ?? pickParam("error");
+        if (errorDescription) {
+          surfaceError(errorDescription);
+          return;
+        }
+
+        const shouldStopDueTo = (maybeError: Error | null | undefined) => {
+          if (!maybeError) return false;
+          const message = maybeError.message ?? "Erro ao recuperar sessão.";
+          if (/code verifier/i.test(message) || /invalid request/i.test(message)) {
+            console.warn("Supabase PKCE fallback:", message);
+            return false;
+          }
+          surfaceError(message);
+          return true;
+        };
+
+        let {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError && shouldStopDueTo(sessionError)) {
+          return;
+        }
+
+        const captureSession = (maybeSession: typeof session) => {
+          if (maybeSession) {
+            session = maybeSession;
+          }
+        };
+
+        const hasCode = Boolean(pickParam("code"));
+        const hasToken = Boolean(pickParam("token"));
+        const hasTokenHash = Boolean(pickParam("token_hash"));
+        const hasAccessPair = Boolean(pickParam("access_token") && pickParam("refresh_token"));
+
+        if (!session && (hasCode || hasAccessPair)) {
+          const { data, error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+          if (error) {
+            if (shouldStopDueTo(error)) {
+              return;
+            }
+          } else {
+            captureSession(data.session);
+          }
+        }
+
+        if (!session && (hasToken || hasTokenHash)) {
+          const rawType = pickParam("type");
+          const emailParam = pickParam("email") ?? pickParam("user_email") ?? undefined;
+          const tokenValue = pickParam("token") ?? pickParam("token_hash");
+          const tokenKey = pickParam("token") ? "token" : "token_hash";
+
+          if (tokenValue) {
+            const typeCandidates = Array.from(
+              new Set(
+                [
+                  rawType,
+                  rawType === "recovery" ? "recovery" : null,
+                  rawType === "signup" ? "signup" : null,
+                  rawType === "invite" ? "invite" : null,
+                  "magiclink",
+                  "email",
+                ].filter(Boolean) as string[],
+              ),
+            );
+
+            let lastError: string | null = null;
+            for (const typeCandidate of typeCandidates) {
+              const verifyPayload = {
+                type: typeCandidate as Parameters<typeof supabase.auth.verifyOtp>[0]["type"],
+                [tokenKey]: tokenValue,
+                ...(emailParam ? { email: emailParam } : {}),
+              } as Parameters<typeof supabase.auth.verifyOtp>[0];
+
+              const { data, error } = await supabase.auth.verifyOtp(verifyPayload);
+              if (error) {
+                lastError = error.message;
+                if (!/token not found/i.test(error.message)) {
+                  break;
+                }
+                continue;
+              }
+              captureSession(data.session);
+              lastError = null;
+              break;
+            }
+
+            if (!session && lastError) {
+              surfaceError(lastError);
+              return;
+            }
+          }
+        }
+
+        if (!session && hasAccessPair) {
+          const accessToken = pickParam("access_token")!;
+          const refreshToken = pickParam("refresh_token")!;
+          const { data, error } = await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
+          if (error) {
+            surfaceError(error.message);
+            return;
+          }
+          captureSession(data.session);
+        }
+
+        if (!session) {
+          surfaceError("Link inválido ou expirado.");
+          return;
+        }
+
+        const accessToken = session.access_token;
+        const refreshToken = session.refresh_token;
+        if (!accessToken || !refreshToken) {
+          surfaceError("Link inválido ou expirado.");
+          return;
+        }
+
+        const syncResponse = await fetch("/auth/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ access_token: accessToken, refresh_token: refreshToken }),
+          cache: "no-store",
+        });
+
+        if (!syncResponse.ok) {
+          const bodyText = await syncResponse.text().catch(() => "Falha ao sincronizar.");
+          surfaceError(bodyText || "Falha ao sincronizar.");
+          return;
+        }
+
+        const clean = new URL(window.location.href);
+        clean.hash = "";
+        clean.search = "";
+        clean.pathname = "/auth/callback";
+        window.history.replaceState({}, "", clean.toString());
+
+        window.location.replace(redirectTo);
+      } catch (error) {
+        console.error("Erro ao processar callback de autenticação", error);
+        const message = error instanceof Error ? error.message : "Erro desconhecido.";
+        surfaceError(message);
+      }
+    };
+
     run();
+
+    return () => {
+      cancelled = true;
+    };
   }, [redirectTo, supabase]);
 
-  return err ? <pre style={{ padding: 16 }}>Erro de autenticação: {err}</pre> : null;
+  return (
+    <Flex
+      direction={Flex.directions.COLUMN}
+      align={Flex.align.CENTER}
+      justify={Flex.justify.CENTER}
+      gap={12}
+      style={{ minHeight: "100vh", padding: 24 }}
+    >
+      {processing && !err ? (
+        <>
+          <Loader size={Loader.sizes.SMALL} />
+          <Text type={Text.types.TEXT2} weight={Text.weights.BOLD}>
+            Confirmando seu acesso...
+          </Text>
+        </>
+      ) : null}
+
+      {err ? (
+        <Text type={Text.types.TEXT3} color={Text.colors.NEGATIVE} align={Text.align.CENTER}>
+          Erro de autenticação: {err}
+        </Text>
+      ) : null}
+    </Flex>
+  );
 }

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -7,8 +7,8 @@ export function createSupabaseBrowserClient() {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       auth: {
-        flowType: "implicit",      // sem PKCE
-        detectSessionInUrl: true,  // lê #access_token no callback e persiste no client
+        flowType: "pkce",          // suporta links magic e troca de código
+        detectSessionInUrl: false, // o callback processa manualmente os parâmetros da URL
       },
     }
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,6 @@
 // middleware.ts
 import { NextRequest, NextResponse } from "next/server";
-
-async function validate(token: string, url: string, anon: string) {
-  const r = await fetch(`${url}/auth/v1/user`, {
-    headers: { Authorization: `Bearer ${token}`, apikey: anon },
-    cache: "no-store",
-  });
-  return r.ok;
-}
+import { createServerClient } from "@supabase/ssr";
 
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
@@ -15,18 +8,57 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  const token = req.cookies.get("sb-access-token")?.value;
+  let response = NextResponse.next();
 
-  if (!token || !(await validate(token, url, anon))) {
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name) {
+          return req.cookies.get(name)?.value;
+        },
+        set(name, value, options) {
+          response.cookies.set({
+            name,
+            value,
+            ...options,
+            path: options?.path ?? "/",
+            sameSite: options?.sameSite ?? "lax",
+          });
+        },
+        remove(name, options) {
+          response.cookies.set({
+            name,
+            value: "",
+            ...options,
+            path: options?.path ?? "/",
+            sameSite: options?.sameSite ?? "lax",
+          });
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
     const to = req.nextUrl.clone();
     to.pathname = "/sign-in";
     to.search = "";
-    to.searchParams.set("redirectTo", pathname + search || "/dashboard");
-    return NextResponse.redirect(to);
+    to.searchParams.set("redirectTo", pathname + (search || "") || "/dashboard");
+
+    const redirectResponse = NextResponse.redirect(to);
+    response.cookies.getAll().forEach((cookie) => {
+      redirectResponse.cookies.set(cookie);
+    });
+    return redirectResponse;
   }
-  return NextResponse.next();
+
+  return response;
 }
 
 export const config = {

--- a/supabase/migrations/004_auto_org_memberships.sql
+++ b/supabase/migrations/004_auto_org_memberships.sql
@@ -1,0 +1,77 @@
+SET search_path = public, pg_temp;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_slug_base text;
+    v_slug text;
+    v_suffix integer := 1;
+    v_name text;
+    v_org_id uuid;
+BEGIN
+    INSERT INTO public.profiles (id, email, raw_user_meta_data, created_at)
+    VALUES (NEW.id, NEW.email, NEW.raw_user_meta_data, timezone('utc'::text, now()))
+    ON CONFLICT (id) DO UPDATE
+      SET email = EXCLUDED.email,
+          raw_user_meta_data = EXCLUDED.raw_user_meta_data;
+
+    v_name := COALESCE(
+      NULLIF(trim(NEW.raw_user_meta_data->>'company'), ''),
+      NULLIF(trim(NEW.raw_user_meta_data->>'name'), ''),
+      INITCAP(regexp_replace(split_part(COALESCE(NEW.email, 'Equipe'), '@', 1), '[-_.]+', ' ', 'g'))
+    );
+
+    v_slug_base := lower(regexp_replace(COALESCE(NEW.raw_user_meta_data->>'company', split_part(COALESCE(NEW.email, 'user'), '@', 1)), '[^a-z0-9-]+', '-', 'g'));
+    v_slug_base := regexp_replace(COALESCE(v_slug_base, ''), '-{2,}', '-', 'g');
+    v_slug_base := trim(both '-' from v_slug_base);
+
+    IF v_slug_base IS NULL OR v_slug_base = '' THEN
+        v_slug_base := 'org-' || replace(left(NEW.id::text, 8), '-', '');
+    END IF;
+
+    v_slug := v_slug_base;
+    WHILE EXISTS (SELECT 1 FROM public.organizations WHERE slug = v_slug) LOOP
+        v_slug := v_slug_base || '-' || v_suffix::text;
+        v_suffix := v_suffix + 1;
+    END LOOP;
+
+    INSERT INTO public.organizations (slug, name, created_by)
+    VALUES (
+      v_slug,
+      COALESCE(v_name, INITCAP(replace(v_slug, '-', ' '))),
+      NEW.id
+    )
+    RETURNING id INTO v_org_id;
+
+    INSERT INTO public.memberships (organization_id, user_id, role, status)
+    VALUES (v_org_id, NEW.id, 'org', 'active')
+    ON CONFLICT (organization_id, user_id) DO UPDATE
+      SET role = EXCLUDED.role,
+          status = EXCLUDED.status;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.handle_deleted_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    DELETE FROM public.profiles WHERE id = OLD.id;
+    RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_deleted ON auth.users;
+
+CREATE TRIGGER on_auth_user_deleted
+AFTER DELETE ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_deleted_user();

--- a/supabase/migrations/005_membership_rls_fix.sql
+++ b/supabase/migrations/005_membership_rls_fix.sql
@@ -1,0 +1,23 @@
+SET search_path = public, pg_temp;
+
+DROP POLICY IF EXISTS memberships_select_org ON public.memberships;
+
+CREATE OR REPLACE FUNCTION public.can_access_membership(org_id uuid, membership_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.visible_membership_ids(org_id) v
+    WHERE v.membership_id = membership_id
+  );
+$$;
+
+CREATE POLICY memberships_select_visible
+ON public.memberships
+FOR SELECT
+USING (
+  public.can_access_membership(memberships.organization_id, memberships.id)
+);


### PR DESCRIPTION
## Summary
- harden `/auth/callback` to prefer `getSessionFromUrl`, retry magic-link verification with tolerant `verifyOtp` fallbacks, and only rely on explicit tokens before syncing cookies so magic links stop erroring out
- replace the recursive `memberships_select_org` policy with a security-definer helper plus `memberships_select_visible` to eliminate the 42P17 infinite recursion when loading memberships
- refresh the changelog and docs with the revised callback order and the new RLS helper notes

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e64e452bcc8324944297b85ceb0e63